### PR TITLE
feat: Bump Swift Tools to 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Test
         run: set -o pipefail && env NSUnbufferedIO=YES swift test --enable-code-coverage
-      - name: Update codecov config
-        run: cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
       - name: Prepare codecov
         run: |
+          cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
           llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseCertificateAuthorityPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info_linux.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,16 +55,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Test
         run: set -o pipefail && env NSUnbufferedIO=YES swift test --enable-code-coverage
-      - name: Prepare codecov
-        run: |
-          cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
-          llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseCertificateAuthorityPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info_linux.lcov
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          env_vars: LINUX
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   docs:
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
       - name: Prepare codecov
         run: |
-          llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseServerSwiftPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info_linux.lcov      - name: Upload coverage to Codecov
+          llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseCertificateAuthorityPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info_linux.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches: [ main ]
 
 env:
-  CI_XCODE: '/Applications/Xcode_15.4.app/Contents/Developer'
+  CI_XCODE: '/Applications/Xcode_26.1.app/Contents/Developer'
 
 concurrency:
    group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,15 +16,15 @@ concurrency:
 
 jobs:
   spm-test:
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install SwiftLint
       run: brew install swiftlint
     - name: Lint
       run: swiftlint --strict
     - name: Build and Test
-      run: swift test --enable-code-coverage
+      run: swift test --enable-code-coverage 2>&1 | xcbeautify --renderer github-actions
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE }}
     - name: Prepare codecov
@@ -48,10 +48,10 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: sersoft-gmbh/SwiftyActions@v3
+      - uses: actions/checkout@v6
+      - uses: vapor/swiftly-action@v0.2
         with:
-          release-version: "5"
+          release-version: "6.2.3"
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Test
         run: swift test --enable-code-coverage
@@ -69,9 +69,9 @@ jobs:
 
   docs:
     timeout-minutes: 20
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Generate Docs
         run: set -o pipefail && env NSUnbufferedIO=YES Scripts/generate-documentation
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
     - name: Install SwiftLint
       run: brew install swiftlint
     - name: Lint
-      run: swiftlint --strict
+      run: set -o pipefail && env NSUnbufferedIO=YES swiftlint --strict
     - name: Build and Test
-      run: swift test --enable-code-coverage 2>&1 | xcbeautify --renderer github-actions
+      run: set -o pipefail && env NSUnbufferedIO=YES swift test --enable-code-coverage 2>&1 | xcbeautify --renderer github-actions
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE }}
     - name: Prepare codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,12 @@ jobs:
           release-version: "6.2.3"
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Test
-        run: swift test --enable-code-coverage
+        run: set -o pipefail && env NSUnbufferedIO=YES swift test --enable-code-coverage
       - name: Update codecov config
         run: cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
       - name: Prepare codecov
         run: |
-          llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseCertificateAuthorityPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info_linux.lcov
+          llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseServerSwiftPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info_linux.lcov      - name: Upload coverage to Codecov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,13 @@ on:
     types: [published]
 
 env:
-  CI_XCODE: '/Applications/Xcode_15.4.app/Contents/Developer'
+  CI_XCODE: '/Applications/Xcode_26.1.app/Contents/Developer'
   
 jobs:
   docs:
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build and Deploy Docs
         run: set -o pipefail && env NSUnbufferedIO=YES Scripts/update-gh-pages-documentation-site
         env:

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,16 +1,15 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "ParseSwift",
-        "repositoryURL": "https://github.com/netreconlab/Parse-Swift.git",
-        "state": {
-          "branch": null,
-          "revision": "fc516a6e48c1c150a0ecac94910bc8dcedfc2e71",
-          "version": "5.8.1"
-        }
+  "originHash" : "ff775761a0cfa63d96dad6d41b52330cab321b2fab40b3a2b8e742874fcdf165",
+  "pins" : [
+    {
+      "identity" : "parse-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/netreconlab/Parse-Swift.git",
+      "state" : {
+        "revision" : "8baacc9f39ef86f80cb8a91aa7a1e7bb6faa547b",
+        "version" : "6.0.0"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5.2
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -14,21 +14,28 @@ let package = Package(
     products: [
         .library(
             name: "ParseCertificateAuthority",
-            targets: ["ParseCertificateAuthority"])
+            targets: ["ParseCertificateAuthority"]
+		)
     ],
     dependencies: [
-        .package(url: "https://github.com/netreconlab/Parse-Swift.git",
-                 .upToNextMajor(from: "5.8.1"))
+        .package(
+			url: "https://github.com/netreconlab/Parse-Swift.git",
+			.upToNextMajor(from: "6.0.0")
+		)
     ],
     targets: [
         .target(
             name: "ParseCertificateAuthority",
             dependencies: [
-                .product(name: "ParseSwift", package: "Parse-Swift")
+                .product(
+					name: "ParseSwift",
+					package: "Parse-Swift"
+				)
             ]
         ),
         .testTarget(
             name: "ParseCertificateAuthorityTests",
-            dependencies: ["ParseCertificateAuthority"])
+            dependencies: ["ParseCertificateAuthority"]
+		)
     ]
 )

--- a/Sources/ParseCertificateAuthority/Extensions/URLSession+async.swift
+++ b/Sources/ParseCertificateAuthority/Extensions/URLSession+async.swift
@@ -14,13 +14,15 @@ import ParseSwift
 extension URLSession {
     func dataTask(for request: URLRequest) async throws -> (Data, URLResponse) {
         try await withCheckedThrowingContinuation { continuation in
-            self.dataTask(with: request,
-                          completionHandler: continuation.resume).resume()
+			self.dataTask(with: request, completionHandler: { continuation.resume(with: $0 ) }
+			).resume()
         }
     }
 
-    func dataTask(with request: URLRequest,
-                  completionHandler: @escaping (Result<(Data, URLResponse), Error>) -> Void) -> URLSessionDataTask {
+    func dataTask(
+		with request: URLRequest,
+		completionHandler: @escaping @Sendable (Result<(Data, URLResponse), Error>) -> Void
+	) -> URLSessionDataTask {
         return dataTask(with: request) { (data, response, error) in
             guard let data = data,
                   let response = response else {

--- a/Sources/ParseCertificateAuthority/ParseCertificateAuthority.swift
+++ b/Sources/ParseCertificateAuthority/ParseCertificateAuthority.swift
@@ -23,5 +23,18 @@ public var configuration: ParseCertificateAuthorityConfiguration {
 }
 
 internal struct ParseCA {
-    static var configuration: ParseCertificateAuthorityConfiguration!
+	static var configuration: ParseCertificateAuthorityConfiguration! {
+		get {
+			lock.lock()
+			defer { lock.unlock() }
+			return _configuration
+		}
+		set {
+			lock.lock()
+			defer { lock.unlock() }
+			_configuration = newValue
+		}
+	}
+	nonisolated(unsafe) static var _configuration: ParseCertificateAuthorityConfiguration!
+	private static let lock = NSLock()
 }

--- a/Sources/ParseCertificateAuthority/ParseCertificateAuthorityConfiguration.swift
+++ b/Sources/ParseCertificateAuthority/ParseCertificateAuthorityConfiguration.swift
@@ -8,8 +8,8 @@
 import Foundation
 import ParseSwift
 
-/// The configuratoin for `ParseCertificateAuthority`.
-public struct ParseCertificateAuthorityConfiguration {
+/// The configuration for `ParseCertificateAuthority`.
+public struct ParseCertificateAuthorityConfiguration: Hashable, Sendable {
 
     /// The full URL of the **ca-server** to access the root certificate.
     public internal(set) var caRootCertificateURL: URL
@@ -26,10 +26,12 @@ public struct ParseCertificateAuthorityConfiguration {
      - parameter caUsersPath: The **ca-server** path to access users.
      - throws: An error of `ParseError` type.
      */
-    public init(caURLString: String,
-                caRootCertificatePath: String = "/ca_certificate",
-                caCertificatesPath: String = "/certificates/",
-                caUsersPath: String = "/appusers/") throws {
+    public init(
+		caURLString: String,
+		caRootCertificatePath: String = "/ca_certificate",
+		caCertificatesPath: String = "/certificates/",
+		caUsersPath: String = "/appusers/"
+	) throws {
         guard let caRootCertificateURL = URL(string: caURLString + caRootCertificatePath) else {
             throw ParseError(code: .otherCause,
                              message: "Could not create a url for \(caURLString + caRootCertificatePath)")

--- a/Sources/ParseCertificateAuthority/Protocals/Certificatable.swift
+++ b/Sources/ParseCertificateAuthority/Protocals/Certificatable.swift
@@ -16,7 +16,7 @@ import ParseSwift
  and methods to support certificates and communicating with a
  [ca-server](https://github.com/netreconlab/ca-server).
  */
-public protocol Certificatable: Hashable {
+public protocol Certificatable: Hashable, Sendable {
     /// The root certificate that signed the `csr` and turned it into a `certificate`.
     var rootCertificate: String? { get set }
 
@@ -60,8 +60,10 @@ public extension Certificatable {
      - note: This is useful when certificates need to be created for the first time. If an object
      already has both certificates, it will simply return the current certificates.
      */
-    func getCertificates(_ userId: String?,
-                         createUserAccountIfNeeded: Bool = true) async throws -> (String?, String?) {
+    func getCertificates(
+		_ userId: String?,
+		createUserAccountIfNeeded: Bool = true
+	) async throws -> (String?, String?) {
 
         guard let userId = userId,
               let certificateId = self.certificateId,
@@ -113,8 +115,10 @@ public extension Certificatable {
      - throws: An error of `ParseError` type.
      - note: This is useful for when certificates have expired.
      */
-    func requestNewCertificates(_ userId: String?,
-                                createUserAccountIfNeeded: Bool = false) async throws -> (String?, String?) {
+    func requestNewCertificates(
+		_ userId: String?,
+		createUserAccountIfNeeded: Bool = false
+	) async throws -> (String?, String?) {
 
         guard let userId = userId,
               let certificateId = self.certificateId,
@@ -149,10 +153,12 @@ public extension Certificatable {
 // MARK: Internal
 extension Certificatable {
 
-    func restfullCertificates(httpMethod: RestMethod,
-                              body: CAServerBody? = nil,
-                              certificateType: CertificateType,
-                              certificateId: String? = nil) async throws -> String {
+    func restfullCertificates(
+		httpMethod: RestMethod,
+		body: CAServerBody? = nil,
+		certificateType: CertificateType,
+		certificateId: String? = nil
+	) async throws -> String {
 
         if certificateType == .root && httpMethod != .GET {
             throw ParseError(code: .otherCause,
@@ -183,8 +189,10 @@ extension Certificatable {
 
     }
 
-    func verifyAndCreateUserOnCA(userId: String,
-                                 createUserAccountIfNeeded: Bool) async throws {
+    func verifyAndCreateUserOnCA(
+		userId: String,
+		createUserAccountIfNeeded: Bool
+	) async throws {
 
         do {
             try await restfullAppUsers(httpMethod: .GET, userId: userId)
@@ -200,9 +208,11 @@ extension Certificatable {
 
     }
 
-    func restfullAppUsers(httpMethod: RestMethod,
-                          body: CAServerBody? = nil,
-                          userId: String?) async throws {
+    func restfullAppUsers(
+		httpMethod: RestMethod,
+		body: CAServerBody? = nil,
+		userId: String?
+	) async throws {
 
         let url: URL!
         if let userId = userId {
@@ -222,9 +232,11 @@ extension Certificatable {
 
     }
 
-    func prepareRequest<V: Encodable>(_ url: URL,
-                                      method: RestMethod,
-                                      body: V?) throws -> URLRequest {
+    func prepareRequest<V: Encodable & Sendable>(
+		_ url: URL,
+		method: RestMethod,
+		body: V?
+	) throws -> URLRequest {
 
         var request = URLRequest(url: url)
         request.httpMethod = method.rawValue

--- a/Sources/ParseCertificateAuthority/Types/CAServerBody.swift
+++ b/Sources/ParseCertificateAuthority/Types/CAServerBody.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct CAServerBody: Codable {
+struct CAServerBody: Codable, Hashable, Sendable {
     var user: String
     var certificateId: String?
     var csr: String?

--- a/Sources/ParseCertificateAuthority/Types/CAServerResponse.swift
+++ b/Sources/ParseCertificateAuthority/Types/CAServerResponse.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct CAServerResponse: Codable {
+struct CAServerResponse: Codable, Hashable, Sendable {
     var user: String
     var certificateId: String
     var csr: String

--- a/Sources/ParseCertificateAuthority/Types/Enums.swift
+++ b/Sources/ParseCertificateAuthority/Types/Enums.swift
@@ -7,13 +7,13 @@
 
 import Foundation
 
-enum RestMethod: String {
+enum RestMethod: String, Hashable, Sendable {
     case GET
     case POST
     case PUT
 }
 
-enum CertificateType: String {
+enum CertificateType: String, Hashable, Sendable {
     case root
     case user
 }

--- a/Tests/ParseCertificateAuthorityTests/NetworkMocking/MockURLResponse.swift
+++ b/Tests/ParseCertificateAuthorityTests/NetworkMocking/MockURLResponse.swift
@@ -9,7 +9,7 @@
 import Foundation
 @testable import ParseSwift
 
-struct MockURLResponse {
+struct MockURLResponse: Sendable {
     var statusCode: Int = 200
     var headerFields = [String: String]()
     var responseData: Data?


### PR DESCRIPTION
This PR upgrades the Swift Tools version from 5.5.2 to 6.0 and updates the codebase to support Swift 6's strict concurrency checking. The changes include adding `Sendable` conformance to types, protecting shared mutable state with locks, and updating closures to be `@Sendable`.

**Changes:**
- Updated Swift tools version to 6.0 and Parse-Swift dependency to 6.0.0
- Added `Sendable` conformance to enums, structs, and protocols throughout the codebase
- Refactored static mutable state to use `nonisolated(unsafe)` with NSLock protection for thread safety
- Modified MockURLProtocol test infrastructure to handle concurrency requirements